### PR TITLE
Use patched riak-ruby-client (closes #32)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "http://rubygems.org"
 gem "sinatra"
 gem "sinatra-contrib"
 gem "activesupport"
-gem "riak-client"
+gem "riak-client", :github => "5apps/riak-ruby-client", :branch => "invalid_uri_error"
 gem "fog"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: git://github.com/5apps/riak-ruby-client.git
+  revision: 5f21df86b14339aeb252374851d29ad813cca1dd
+  branch: invalid_uri_error
+  specs:
+    riak-client (1.4.0)
+      beefcake (~> 0.3.7)
+      builder (>= 2.1.2)
+      i18n (>= 0.4.0)
+      innertube (~> 1.0.2)
+      multi_json (~> 1.0)
+
 GEM
   remote: http://rubygems.org/
   specs:
@@ -47,12 +59,6 @@ GEM
       unicorn (~> 4.1)
     raindrops (0.10.0)
     rake (0.9.2.2)
-    riak-client (1.4.1)
-      beefcake (~> 0.3.7)
-      builder (>= 2.1.2)
-      i18n (>= 0.4.0)
-      innertube (~> 1.0.2)
-      multi_json (~> 1.0)
     ruby-hmac (0.4.0)
     sinatra (1.4.3)
       rack (~> 1.4)
@@ -81,6 +87,6 @@ DEPENDENCIES
   purdytest
   rainbows
   rake
-  riak-client
+  riak-client!
   sinatra
   sinatra-contrib

--- a/spec/riak_spec.rb
+++ b/spec/riak_spec.rb
@@ -435,6 +435,19 @@ describe "App with Riak backend" do
         end
       end
 
+      context "escaped square brackets in key" do
+        before do
+          put "/jimmy/documents/gracehopper%5B1%5D.jpg", "super image"
+        end
+
+        it "delivers the data correctly" do
+          header "Authorization", "Bearer 123"
+          get "/jimmy/documents/gracehopper%5B1%5D.jpg"
+
+          last_response.body.must_equal "super image"
+        end
+      end
+
       context "invalid JSON" do
         context "empty body" do
           before do


### PR DESCRIPTION
The patched version escapes square brackets in the
key and bucket names correctly.
