### PR TITLE
Opslog fix for binary files

### DIFF
--- a/lib/remote_storage/riak.rb
+++ b/lib/remote_storage/riak.rb
@@ -173,11 +173,14 @@ module RemoteStorage
     end
 
     def log_operation(user, directory, count, new_size=0, old_size=0)
+      size = (-old_size + new_size)
+      return if count == 0 && size == 0
+
       log_entry = opslog_bucket.new
       log_entry.content_type = "application/json"
       log_entry.data = {
         "count" => count,
-        "size" => (-old_size + new_size),
+        "size" => size,
         "category" => extract_category(directory)
       }
       log_entry.indexes.merge!({:user_id_bin => [user]})

--- a/spec/riak_spec.rb
+++ b/spec/riak_spec.rb
@@ -398,6 +398,22 @@ describe "App with Riak backend" do
             log_entry.indexes["user_id_bin"].must_include "jimmy"
           end
 
+          context "overwriting existing file with same file" do
+            before do
+              header "Content-Type", "image/jpeg; charset=binary"
+              filename = File.join(File.expand_path(File.dirname(__FILE__)), "fixtures", "rockrule.jpeg")
+              @image = File.open(filename, "r").read
+              put "/jimmy/documents/jaypeg", @image
+            end
+
+            it "doesn't log the operation" do
+              objects = []
+              opslog_bucket.keys.each { |k| objects << opslog_bucket.get(k) rescue nil }
+
+              objects.size.must_equal 1
+            end
+          end
+
           context "overwriting existing file with different file" do
             before do
               header "Content-Type", "image/jpeg; charset=binary"


### PR DESCRIPTION
When updating an existing binary file, an opslog with count of 1 instead of 0 was created 
