### PR TITLE
Update activesupport, i18n and nokogiri gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 gem "sinatra"
 gem "sinatra-contrib"
-gem "activesupport"
+gem "activesupport", '~> 3.2'
 gem "riak-client", :github => "5apps/riak-ruby-client", :branch => "invalid_uri_error"
 gem "fog"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,8 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (3.2.13)
-      i18n (= 0.6.1)
+    activesupport (3.2.18)
+      i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
     backports (3.3.0)
     beefcake (0.3.7)
@@ -32,7 +32,7 @@ GEM
       nokogiri (~> 1.5.0)
       ruby-hmac
     formatador (0.2.4)
-    i18n (0.6.1)
+    i18n (0.6.9)
     innertube (1.0.2)
     kgio (2.9.2)
     m (1.2.1)
@@ -41,11 +41,11 @@ GEM
     method_source (0.8)
     mime-types (1.23)
     minitest (2.10.0)
-    multi_json (1.8.0)
+    multi_json (1.10.0)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
     net-ssh (2.6.7)
-    nokogiri (1.5.10)
+    nokogiri (1.5.11)
     purdytest (1.0.0)
       minitest (~> 2.2)
     rack (1.5.2)
@@ -81,7 +81,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (~> 3.2)
   fog
   m
   purdytest


### PR DESCRIPTION
The old activesupport gem depended on i18n 0.6.1
