### PR TITLE
Always cast the Content-Length header into a string

### DIFF
--- a/lib/remote_storage/riak.rb
+++ b/lib/remote_storage/riak.rb
@@ -168,7 +168,7 @@ module RemoteStorage
     def set_object_response_headers(object)
       server.headers["Content-Type"]   = object.content_type
       server.headers["ETag"]           = object.etag
-      server.headers["Content-Length"] = object_size(object)
+      server.headers["Content-Length"] = object_size(object).to_s
     end
 
     def set_directory_response_headers(directory_object)

--- a/spec/riak_spec.rb
+++ b/spec/riak_spec.rb
@@ -29,7 +29,7 @@ describe "App with Riak backend" do
 
     it "has a Content-Length header set" do
       last_response.status.must_equal 200
-      last_response.headers["Content-Length"].must_equal 14
+      last_response.headers["Content-Length"].must_equal '14'
     end
   end
 
@@ -129,7 +129,7 @@ describe "App with Riak backend" do
 
       it "has a Content-Length header set" do
         last_response.status.must_equal 200
-        last_response.headers["Content-Length"].must_equal 22
+        last_response.headers["Content-Length"].must_equal '22'
       end
     end
 


### PR DESCRIPTION
Fixes a crash in Rainbows, when a header is set to a Fixnum/Integer.

Refs #53