### PR TITLE
Fix uploads to root directory

### DIFF
--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -293,7 +293,7 @@ module RemoteStorage
     end
 
     def url_for_key(user, directory, key)
-      "#{container_url_for(user)}/#{escape(directory)}/#{escape(key)}"
+      File.join [container_url_for(user), escape(directory), escape(key)].compact
     end
 
     def url_for_directory(user, directory)


### PR DESCRIPTION
The `url_for_key` method returned a double slash because `directory` is an empty string when uploading to the root directory

Fixes #70