### PR TITLE
Migration script for copying metadata to Redis

### DIFF
--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -87,11 +87,11 @@ module RemoteStorage
       lua_script = <<-EOF
         local user = ARGV[1]
         local directory = ARGV[2]
-        local items = redis.call("smembers", "rsm:"..user..":"..directory.."/:i")
+        local items = redis.call("smembers", "rs:m:"..user..":"..directory.."/:i")
         local listing = {}
 
         for index, name in pairs(items) do
-          local redis_key = "rsm:"..user..":"
+          local redis_key = "rs:m:"..user..":"
           if directory == "" then
             redis_key = redis_key..name
           else
@@ -121,7 +121,7 @@ module RemoteStorage
     end
 
     def get_directory_listing_from_redis(user, directory)
-      etag = redis.hget "rsm:#{user}:#{directory}/", "e"
+      etag = redis.hget "rs:m:#{user}:#{directory}/", "e"
 
       none_match = (server.env["HTTP_IF_NONE_MATCH"] || "").split(",").map(&:strip)
       server.halt 304 if none_match.include? etag
@@ -313,7 +313,7 @@ module RemoteStorage
         end
 
         -- check for existing directory with the same name as the document
-        local redis_key = "rsm:"..user..":"
+        local redis_key = "rs:m:"..user..":"
         if directory == "" then
           redis_key = redis_key..key.."/"
         else
@@ -324,12 +324,12 @@ module RemoteStorage
         end
 
         for index, dir in pairs(parent_directories) do
-          if redis.call("hget", "rsm:"..user..":"..dir.."/", "e") then
+          if redis.call("hget", "rs:m:"..user..":"..dir.."/", "e") then
             -- the directory already exists, no need to do further checks
             return false
           else
             -- check for existing document with same name as directory
-            if redis.call("hget", "rsm:"..user..":"..dir, "e") then
+            if redis.call("hget", "rs:m:"..user..":"..dir, "e") then
               return true
             end
           end
@@ -401,9 +401,9 @@ module RemoteStorage
     end
 
     def update_metadata_object(user, directory, key, metadata)
-      redis_key = "rsm:#{user}:#{directory}/#{key}"
+      redis_key = "rs:m:#{user}:#{directory}/#{key}"
       redis.hmset(redis_key, *metadata)
-      redis.sadd "rsm:#{user}:#{directory}/:i", key
+      redis.sadd "rs:m:#{user}:#{directory}/:i", key
 
       true
     end
@@ -418,10 +418,10 @@ module RemoteStorage
           etag = etag_for(get_response.body)
         end
 
-        key = "rsm:#{user}:#{dir}/"
+        key = "rs:m:#{user}:#{dir}/"
         metadata = {e: etag, m: timestamp}
         redis.hmset(key, *metadata)
-        redis.sadd "rsm:#{user}:#{parent_directory_for(dir)}:i", "#{top_directory(dir)}/"
+        redis.sadd "rs:m:#{user}:#{parent_directory_for(dir)}:i", "#{top_directory(dir)}/"
       end
 
       true
@@ -436,9 +436,9 @@ module RemoteStorage
     end
 
     def delete_metadata_objects(user, directory, key)
-      redis_key = "rsm:#{user}:#{directory}/#{key}"
+      redis_key = "rs:m:#{user}:#{directory}/#{key}"
       redis.del(redis_key)
-      redis.srem "rsm:#{user}:#{directory}/:i", key
+      redis.srem "rs:m:#{user}:#{directory}/:i", key
     end
 
     def delete_dir_objects(user, directory)
@@ -449,8 +449,8 @@ module RemoteStorage
           unless dir == ""
             do_delete_request("#{url_for_directory(user, dir)}/")
           end
-          redis.del "rsm:#{user}:#{directory}/"
-          redis.srem "rsm:#{user}:#{parent_directory_for(dir)}:i", "#{dir}/"
+          redis.del "rs:m:#{user}:#{directory}/"
+          redis.srem "rs:m:#{user}:#{parent_directory_for(dir)}:i", "#{dir}/"
         else
           unless dir == ""
             res = do_put_request("#{url_for_directory(user, dir)}/", timestamp.to_s, "text/plain")
@@ -460,14 +460,14 @@ module RemoteStorage
             etag = etag_for(get_response.body)
           end
           metadata = {e: etag, m: timestamp}
-          redis.hmset("rsm:#{user}:#{dir}/", *metadata)
+          redis.hmset("rs:m:#{user}:#{dir}/", *metadata)
         end
       end
     end
 
     def dir_empty?(user, dir)
       if directory_backend(user).match(/new/)
-        redis.smembers("rsm:#{user}:#{dir}/:i").empty?
+        redis.smembers("rs:m:#{user}:#{dir}/:i").empty?
       else
         do_get_request("#{container_url_for(user)}/?format=plain&limit=1&path=#{escape(dir)}/") do |res|
           return res.headers[:content_length] == "0"

--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -537,7 +537,7 @@ module RemoteStorage
     end
 
     def directory_backend(user)
-      @directory_backend ||= redis.get("rs_config:dir_backend:#{user}") || "legacy"
+      @directory_backend ||= redis.get("rsc:db:#{user}") || "legacy"
     end
 
     def etag_for(body)

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+
+require "rest_client"
+require "redis"
+
+class Migrator
+
+  attr_accessor :username, :token, :base_url
+
+  def initialize(username, token)
+    @username = username
+    @token = token
+    @base_url = "https://storage.5apps.com"
+  end
+
+  def configure_redis(redis_config)
+    @redis_config = redis_config
+  end
+
+  def root_url
+    "#{@base_url}/#{@username}"
+  end
+
+  def headers
+    {"authorization" => "Bearer #{@token}"}
+  end
+
+  def is_dir?(name)
+    name[-1] == "/"
+  end
+
+  def url_for(directory, parent_directory="")
+    # base_path = [root_url, parent_directory].join("/")
+    "#{root_url}#{parent_directory}#{directory}"
+  end
+
+  def migrate
+    work_on_dir("", "/")
+  end
+
+  def work_on_dir(directory, parent_directory)
+    url = url_for(directory, parent_directory)
+
+    # puts "work on dir: #{url}"
+
+    response = RestClient.get(url, headers)
+    listing = JSON.parse(response.body)
+
+    timestamp = (Time.now.to_f * 1000).to_i
+
+    if listing["items"].any?
+      items = listing["items"]
+      items.each do |item, data|
+        if is_dir? item
+          save_directory_data("#{parent_directory}#{directory}", item, data, timestamp)
+
+          # get dir listing and repeat
+          work_on_dir(item, "#{parent_directory}#{directory}")
+        else
+          save_document_data("#{parent_directory}#{directory}", item, data, timestamp)
+        end
+
+        add_item_to_parent_dir("#{parent_directory}#{directory}", item)
+      end
+    end
+  end
+
+  def add_item_to_parent_dir(dir, item)
+    key = "rs_meta:#{username}:#{parent_directory_for(dir)}:items"
+    # puts "adding item #{item} to #{key}"
+    redis.sadd key, item
+  end
+
+  def save_directory_data(dir, item, data, timestamp)
+    key = "rs_meta:#{username}:#{dir.gsub(/^\//, "")}#{item}"
+    metadata = {etag: data["ETag"], modified: timestamp}
+
+    # puts "metadata for dir #{key}: #{metadata}"
+    redis.hmset(key, *metadata)
+  end
+
+  def save_document_data(dir, item, data, timestamp)
+    key = "rs_meta:#{username}:#{dir.gsub(/^\//, "")}#{item}"
+    metadata = {
+      etag: data["ETag"],
+      size: data["Content-Length"],
+      type: data["Content-Type"],
+      modified: timestamp
+    }
+    # puts "metadata for document #{key}: #{metadata}"
+    redis.hmset(key, *metadata)
+  end
+
+  def parent_directory_for(directory)
+    return directory if directory == "/"
+
+    return directory[0..directory.rindex("/")].gsub(/^\//, "")
+  end
+
+  def redis
+    @redis ||= Redis.new(@redis_config)
+  end
+
+end
+
+username = ARGV[0]
+token = ARGV[1]
+
+migrator = Migrator.new username, token
+migrator.configure_redis({host: "localhost", port: 6379})
+
+migrator.migrate
+
+
+
+
+

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -2,27 +2,27 @@
 
 require "rest_client"
 require "redis"
+require "yaml"
 
 class Migrator
 
-  attr_accessor :username, :token, :base_url
+  attr_accessor :username, :base_url, :swift_host, :swift_token,
+                :environment, :dry_run, :logging, :settings
 
-  def initialize(username, token)
+  def initialize(username)
     @username = username
-    @token = token
-    @base_url = "https://storage.5apps.com"
-  end
 
-  def configure_redis(redis_config)
-    @redis_config = redis_config
+    @environment = ENV["ENVIRONMENT"] || "staging"
+    @settings = YAML.load(File.read('config.yml'))[@environment]
+    @swift_host = @settings["swift"]["host"]
+    @swift_token = File.read("tmp/swift_token.txt")
+
+    @dry_run = false # disables writing anything to Redis when true
+    @logging = true
   end
 
   def root_url
     "#{@base_url}/#{@username}"
-  end
-
-  def headers
-    {"authorization" => "Bearer #{@token}"}
   end
 
   def is_dir?(name)
@@ -30,21 +30,17 @@ class Migrator
   end
 
   def url_for(directory, parent_directory="")
-    # base_path = [root_url, parent_directory].join("/")
     "#{root_url}#{parent_directory}#{directory}"
   end
 
   def migrate
-    work_on_dir("", "/")
+    work_on_dir("", "")
   end
 
   def work_on_dir(directory, parent_directory)
-    url = url_for(directory, parent_directory)
+    puts "retrieving listing for '#{parent_directory}#{directory}'" if logging
 
-    # puts "work on dir: #{url}"
-
-    response = RestClient.get(url, headers)
-    listing = JSON.parse(response.body)
+    listing = get_directory_listing_from_swift("#{parent_directory}#{directory}")
 
     timestamp = (Time.now.to_f * 1000).to_i
 
@@ -67,16 +63,16 @@ class Migrator
 
   def add_item_to_parent_dir(dir, item)
     key = "rs_meta:#{username}:#{parent_directory_for(dir)}:items"
-    # puts "adding item #{item} to #{key}"
-    redis.sadd key, item
+    puts "adding item #{item} to #{key}" if logging
+    redis.sadd(key, item) unless dry_run
   end
 
   def save_directory_data(dir, item, data, timestamp)
     key = "rs_meta:#{username}:#{dir.gsub(/^\//, "")}#{item}"
     metadata = {etag: data["ETag"], modified: timestamp}
 
-    # puts "metadata for dir #{key}: #{metadata}"
-    redis.hmset(key, *metadata)
+    puts "metadata for dir #{key}: #{metadata}" if logging
+    redis.hmset(key, *metadata) unless dry_run
   end
 
   def save_document_data(dir, item, data, timestamp)
@@ -87,31 +83,132 @@ class Migrator
       type: data["Content-Type"],
       modified: timestamp
     }
-    # puts "metadata for document #{key}: #{metadata}"
-    redis.hmset(key, *metadata)
+    puts "metadata for document #{key}: #{metadata}" if logging
+    redis.hmset(key, *metadata) unless dry_run
   end
 
   def parent_directory_for(directory)
-    return directory if directory == "/"
-
-    return directory[0..directory.rindex("/")].gsub(/^\//, "")
+    if directory.match(/\//)
+      return directory[0..directory.rindex("/")]
+    else
+      return "/"
+    end
   end
 
   def redis
-    @redis ||= Redis.new(@redis_config)
+    @redis ||= Redis.new(@settings["redis"])
   end
 
+  def get_directory_listing_from_swift(directory)
+    is_root_listing = directory.empty?
+
+    get_response = nil
+
+    do_head_request("#{url_for_directory(@username, directory)}") do |response|
+      return directory_listing([]) if response.code == 404
+
+      if is_root_listing
+        get_response = do_get_request("#{container_url_for(@username)}/?format=json&path=")
+      else
+        get_response = do_get_request("#{container_url_for(@username)}/?format=json&path=#{escape(directory)}/")
+      end
+    end
+
+    if body = JSON.parse(get_response.body)
+      listing = directory_listing(body)
+    else
+      puts "listing not JSON"
+    end
+
+    listing
+  end
+
+  def directory_listing(res_body)
+    listing = {
+      "@context" => "http://remotestorage.io/spec/folder-description",
+      "items"    => {}
+    }
+
+    res_body.each do |entry|
+      name = entry["name"]
+      name.sub!("#{File.dirname(entry["name"])}/", '')
+      if name[-1] == "/" # It's a directory
+        listing["items"].merge!({
+          name => {
+            "ETag"           => entry["hash"],
+          }
+        })
+      else # It's a file
+        listing["items"].merge!({
+          name => {
+            "ETag"           => entry["hash"],
+            "Content-Type"   => entry["content_type"],
+            "Content-Length" => entry["bytes"]
+          }
+        })
+      end
+    end
+
+    listing
+  end
+
+  def etag_for(body)
+    objects = JSON.parse(body)
+
+    if objects.empty?
+      Digest::MD5.hexdigest ""
+    else
+      Digest::MD5.hexdigest objects.map { |o| o["hash"] }.join
+    end
+  end
+
+  def do_head_request(url, &block)
+    RestClient.head(url, default_headers, &block)
+  end
+
+  def do_get_request(url, &block)
+    RestClient.get(url, default_headers, &block)
+  end
+
+  def default_headers
+    {"x-auth-token" => @swift_token}
+  end
+
+  def url_for_directory(user, directory)
+    if directory.empty?
+      container_url_for(user)
+    else
+      "#{container_url_for(user)}/#{escape(directory)}"
+    end
+  end
+
+  def container_url_for(user)
+    "#{base_url}/#{container_for(user)}"
+  end
+
+  def base_url
+    @base_url ||= @swift_host
+  end
+
+  def container_for(user)
+    "rs:#{environment.to_s.chars.first}:#{user}"
+  end
+
+  def escape(url)
+    # We want spaces to turn into %20 and slashes to stay slashes
+    CGI::escape(url).gsub('+', '%20').gsub('%2F', '/')
+  end
 end
 
 username = ARGV[0]
-token = ARGV[1]
 
-migrator = Migrator.new username, token
-migrator.configure_redis({host: "localhost", port: 6379})
+unless username
+  puts "No username given."
+  puts "Usage:"
+  puts "ENVIRONMENT=staging ./migrate_metadata_to_redis.rb <username>"
+  exit 1
+end
 
+migrator = Migrator.new username
 migrator.migrate
-
-
-
-
 

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -85,13 +85,13 @@ class Migrator
   end
 
   def add_item_to_parent_dir(dir, item)
-    key = "rs_meta:#{username}:#{parent_directory_for(dir)}:items"
+    key = "rsm:#{username}:#{parent_directory_for(dir)}:i"
     logger.debug "Adding item #{item} to #{key}"
     redis.sadd(key, item) unless dry_run
   end
 
   def save_directory_data(dir, item, data, timestamp)
-    key = "rs_meta:#{username}:#{dir.gsub(/^\//, "")}#{item}"
+    key = "rsm:#{username}:#{dir.gsub(/^\//, "")}#{item}"
     metadata = {
       etag: data["ETag"],
       modified: timestamp_for(data["Last-Modified"])
@@ -102,7 +102,7 @@ class Migrator
   end
 
   def save_document_data(dir, item, data)
-    key = "rs_meta:#{username}:#{dir.gsub(/^\//, "")}#{item}"
+    key = "rsm:#{username}:#{dir.gsub(/^\//, "")}#{item}"
     metadata = {
       etag: data["ETag"],
       size: data["Content-Length"],

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -19,7 +19,7 @@ class Migrator
     @swift_host = @settings["swift"]["host"]
     @swift_token = File.read("tmp/swift_token.txt")
 
-    @dry_run = false # disables writing anything to Redis when true
+    @dry_run = ENV["DRYRUN"] || false # disables writing anything to Redis when true
 
     @logger = Logger.new("log/migrate_metadata_to_redis.log")
     log_level = ENV["LOGLEVEL"] || "INFO"

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -85,7 +85,7 @@ class Migrator
   end
 
   def add_item_to_parent_dir(dir, item)
-    key = "rs:m:#{username}:#{parent_directory_for(dir)}:i"
+    key = "rs:m:#{username}:#{parent_directory_for(dir)}:items"
     logger.debug "Adding item #{item} to #{key}"
     redis.sadd(key, item) unless dry_run
   end

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -85,13 +85,13 @@ class Migrator
   end
 
   def add_item_to_parent_dir(dir, item)
-    key = "rsm:#{username}:#{parent_directory_for(dir)}:i"
+    key = "rs:m:#{username}:#{parent_directory_for(dir)}:i"
     logger.debug "Adding item #{item} to #{key}"
     redis.sadd(key, item) unless dry_run
   end
 
   def save_directory_data(dir, item, data, timestamp)
-    key = "rsm:#{username}:#{dir.gsub(/^\//, "")}#{item}"
+    key = "rs:m:#{username}:#{dir.gsub(/^\//, "")}#{item}"
     metadata = {
       e: data["ETag"],
       m: timestamp_for(data["Last-Modified"])
@@ -102,7 +102,7 @@ class Migrator
   end
 
   def save_document_data(dir, item, data)
-    key = "rsm:#{username}:#{dir.gsub(/^\//, "")}#{item}"
+    key = "rs:m:#{username}:#{dir.gsub(/^\//, "")}#{item}"
     metadata = {
       e: data["ETag"],
       s: data["Content-Length"],

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -4,6 +4,7 @@ require "rest_client"
 require "redis"
 require "yaml"
 require "logger"
+require "active_support/core_ext/hash"
 
 class Migrator
 
@@ -118,7 +119,7 @@ class Migrator
   end
 
   def redis
-    @redis ||= Redis.new(@settings["redis"])
+    @redis ||= Redis.new(@settings["redis"].symbolize_keys)
   end
 
   def get_directory_listing_from_swift(directory)

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -133,7 +133,7 @@ class Migrator
       if is_root_listing
         get_response = do_get_request("#{container_url_for(@username)}/?format=json&path=")
       else
-        get_response = do_get_request("#{container_url_for(@username)}/?format=json&path=#{escape(directory)}/")
+        get_response = do_get_request("#{container_url_for(@username)}/?format=json&path=#{escape(directory)}")
       end
     end
 

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -57,7 +57,7 @@ class Migrator
   end
 
   def set_directory_backend(backend)
-    redis.set("rs_config:dir_backend:#{username}", backend) unless dry_run
+    redis.set("rsc:db:#{username}", backend) unless dry_run
   end
 
   def work_on_dir(directory, parent_directory)

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -93,8 +93,8 @@ class Migrator
   def save_directory_data(dir, item, data, timestamp)
     key = "rsm:#{username}:#{dir.gsub(/^\//, "")}#{item}"
     metadata = {
-      etag: data["ETag"],
-      modified: timestamp_for(data["Last-Modified"])
+      e: data["ETag"],
+      m: timestamp_for(data["Last-Modified"])
     }
 
     logger.debug "Metadata for dir #{key}: #{metadata}"
@@ -104,10 +104,10 @@ class Migrator
   def save_document_data(dir, item, data)
     key = "rsm:#{username}:#{dir.gsub(/^\//, "")}#{item}"
     metadata = {
-      etag: data["ETag"],
-      size: data["Content-Length"],
-      type: data["Content-Type"],
-      modified: timestamp_for(data["Last-Modified"])
+      e: data["ETag"],
+      s: data["Content-Length"],
+      t: data["Content-Type"],
+      m: timestamp_for(data["Last-Modified"])
     }
     logger.debug "Metadata for document #{key}: #{metadata}"
     redis.hmset(key, *metadata) unless dry_run

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -47,7 +47,8 @@ class Migrator
     rescue Exception => ex
       logger.error "Error migrating metadata for '#{username}': #{ex}"
       set_directory_backend("legacy")
-      # TODO write username to file for later reference
+      # write username to file for later reference
+      File.open('log/failed_migration.log', 'a') { |f| f.puts username }
       exit 1
     end
     set_directory_backend("new")

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -18,7 +18,7 @@ class Migrator
     @settings = YAML.load(File.read('config.yml'))[@environment]
 
     @swift_host = @settings["swift"]["host"]
-    @swift_token = File.read("tmp/swift_token.txt")
+    @swift_token = File.read("tmp/swift_token.txt").strip
 
     @dry_run = ENV["DRYRUN"] || false # disables writing anything to Redis when true
 

--- a/migrate_metadata_to_redis.rb
+++ b/migrate_metadata_to_redis.rb
@@ -34,7 +34,20 @@ class Migrator
   end
 
   def migrate
-    work_on_dir("", "")
+    set_directory_backend("legacy_locked")
+    begin
+      work_on_dir("", "")
+    rescue Exception => ex
+      puts "Error migrating metadata for '#{username}': #{ex}" if logging
+      set_directory_backend("legacy")
+      # TODO write username to file for later reference
+      exit 1
+    end
+    set_directory_backend("new")
+  end
+
+  def set_directory_backend(backend)
+    redis.set("rs_config:dir_backend:#{username}", backend) unless dry_run
   end
 
   def work_on_dir(directory, parent_directory)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,7 +39,7 @@ if app.settings.respond_to? :redis
   end
 
   def purge_redis
-    redis.keys("rs_*").each do |key|
+    redis.keys("rs*").each do |key|
       redis.del key
     end
   end

--- a/spec/swift/app_spec.rb
+++ b/spec/swift/app_spec.rb
@@ -31,7 +31,7 @@ describe "App" do
           put "/phil/food/aguacate", "si"
         end
 
-        metadata = redis.hgetall "rs_meta:phil:food/aguacate"
+        metadata = redis.hgetall "rsm:phil:food/aguacate"
         metadata["size"].must_equal "2"
         metadata["type"].must_equal "text/plain; charset=utf-8"
         metadata["etag"].must_equal "bla"
@@ -50,20 +50,20 @@ describe "App" do
           end
         end
 
-        metadata = redis.hgetall "rs_meta:phil:/"
+        metadata = redis.hgetall "rsm:phil:/"
         metadata["etag"].must_equal "rootetag"
         metadata["modified"].length.must_equal 13
 
-        metadata = redis.hgetall "rs_meta:phil:food/"
+        metadata = redis.hgetall "rsm:phil:food/"
         metadata["etag"].must_equal "bla"
         metadata["modified"].length.must_equal 13
 
-        food_items = redis.smembers "rs_meta:phil:food/:items"
+        food_items = redis.smembers "rsm:phil:food/:i"
         food_items.each do |food_item|
           ["camaron", "aguacate"].must_include food_item
         end
 
-        root_items = redis.smembers "rs_meta:phil:/:items"
+        root_items = redis.smembers "rsm:phil:/:i"
         root_items.must_equal ["food/"]
       end
 
@@ -81,7 +81,7 @@ describe "App" do
 
           last_response.status.must_equal 200
 
-          metadata = redis.hgetall "rs_meta:phil:food/aguacate"
+          metadata = redis.hgetall "rsm:phil:food/aguacate"
           metadata["size"].must_equal "2"
         end
 
@@ -94,7 +94,7 @@ describe "App" do
 
           last_response.status.must_equal 409
 
-          metadata = redis.hgetall "rs_meta:phil:food"
+          metadata = redis.hgetall "rsm:phil:food"
           metadata.must_be_empty
         end
 
@@ -107,7 +107,7 @@ describe "App" do
 
           last_response.status.must_equal 409
 
-          metadata = redis.hgetall "rs_meta:phil:food/aguacate/empanado"
+          metadata = redis.hgetall "rsm:phil:food/aguacate/empanado"
           metadata.must_be_empty
         end
       end
@@ -123,7 +123,7 @@ describe "App" do
 
             last_response.status.must_equal 503
 
-            metadata = redis.hgetall "rs_meta:phil:food/aguacate"
+            metadata = redis.hgetall "rsm:phil:food/aguacate"
             metadata.must_be_empty
           end
         end
@@ -138,7 +138,7 @@ describe "App" do
 
             last_response.status.must_equal 503
 
-            metadata = redis.hgetall "rs_meta:phil:food/aguacate"
+            metadata = redis.hgetall "rsm:phil:food/aguacate"
             metadata.must_be_empty
           end
         end
@@ -178,12 +178,12 @@ describe "App" do
           end
         end
 
-        metadata = redis.hgetall "rs_meta:phil:food/aguacate"
+        metadata = redis.hgetall "rsm:phil:food/aguacate"
         metadata.must_be_empty
       end
 
       it "deletes the directory objects metadata in redis" do
-        old_metadata = redis.hgetall "rs_meta:phil:food/"
+        old_metadata = redis.hgetall "rsm:phil:food/"
 
         put_stub = OpenStruct.new(headers: {etag: "newetag"})
         get_stub = OpenStruct.new(body: "rootbody")
@@ -197,15 +197,15 @@ describe "App" do
           end
         end
 
-        metadata = redis.hgetall "rs_meta:phil:food/"
+        metadata = redis.hgetall "rsm:phil:food/"
         metadata["etag"].must_equal "newetag"
         metadata["modified"].length.must_equal 13
         metadata["modified"].wont_equal old_metadata["modified"]
 
-        food_items = redis.smembers "rs_meta:phil:food/:items"
+        food_items = redis.smembers "rsm:phil:food/:i"
         food_items.must_equal ["camaron"]
 
-        root_items = redis.smembers "rs_meta:phil:/:items"
+        root_items = redis.smembers "rsm:phil:/:i"
         root_items.must_equal ["food/"]
       end
 
@@ -223,13 +223,13 @@ describe "App" do
           end
         end
 
-        metadata = redis.hgetall "rs_meta:phil:food/"
+        metadata = redis.hgetall "rsm:phil:food/"
         metadata.must_be_empty
 
-        food_items = redis.smembers "rs_meta:phil:food/:items"
+        food_items = redis.smembers "rsm:phil:food/:i"
         food_items.must_be_empty
 
-        root_items = redis.smembers "rs_meta:phil:/:items"
+        root_items = redis.smembers "rsm:phil:/:i"
         root_items.must_be_empty
       end
     end

--- a/spec/swift/app_spec.rb
+++ b/spec/swift/app_spec.rb
@@ -31,7 +31,7 @@ describe "App" do
           put "/phil/food/aguacate", "si"
         end
 
-        metadata = redis.hgetall "rsm:phil:food/aguacate"
+        metadata = redis.hgetall "rs:m:phil:food/aguacate"
         metadata["s"].must_equal "2"
         metadata["t"].must_equal "text/plain; charset=utf-8"
         metadata["e"].must_equal "bla"
@@ -50,20 +50,20 @@ describe "App" do
           end
         end
 
-        metadata = redis.hgetall "rsm:phil:/"
+        metadata = redis.hgetall "rs:m:phil:/"
         metadata["e"].must_equal "rootetag"
         metadata["m"].length.must_equal 13
 
-        metadata = redis.hgetall "rsm:phil:food/"
+        metadata = redis.hgetall "rs:m:phil:food/"
         metadata["e"].must_equal "bla"
         metadata["m"].length.must_equal 13
 
-        food_items = redis.smembers "rsm:phil:food/:i"
+        food_items = redis.smembers "rs:m:phil:food/:i"
         food_items.each do |food_item|
           ["camaron", "aguacate"].must_include food_item
         end
 
-        root_items = redis.smembers "rsm:phil:/:i"
+        root_items = redis.smembers "rs:m:phil:/:i"
         root_items.must_equal ["food/"]
       end
 
@@ -81,7 +81,7 @@ describe "App" do
 
           last_response.status.must_equal 200
 
-          metadata = redis.hgetall "rsm:phil:food/aguacate"
+          metadata = redis.hgetall "rs:m:phil:food/aguacate"
           metadata["s"].must_equal "2"
         end
 
@@ -94,7 +94,7 @@ describe "App" do
 
           last_response.status.must_equal 409
 
-          metadata = redis.hgetall "rsm:phil:food"
+          metadata = redis.hgetall "rs:m:phil:food"
           metadata.must_be_empty
         end
 
@@ -107,7 +107,7 @@ describe "App" do
 
           last_response.status.must_equal 409
 
-          metadata = redis.hgetall "rsm:phil:food/aguacate/empanado"
+          metadata = redis.hgetall "rs:m:phil:food/aguacate/empanado"
           metadata.must_be_empty
         end
       end
@@ -123,7 +123,7 @@ describe "App" do
 
             last_response.status.must_equal 503
 
-            metadata = redis.hgetall "rsm:phil:food/aguacate"
+            metadata = redis.hgetall "rs:m:phil:food/aguacate"
             metadata.must_be_empty
           end
         end
@@ -138,7 +138,7 @@ describe "App" do
 
             last_response.status.must_equal 503
 
-            metadata = redis.hgetall "rsm:phil:food/aguacate"
+            metadata = redis.hgetall "rs:m:phil:food/aguacate"
             metadata.must_be_empty
           end
         end
@@ -178,12 +178,12 @@ describe "App" do
           end
         end
 
-        metadata = redis.hgetall "rsm:phil:food/aguacate"
+        metadata = redis.hgetall "rs:m:phil:food/aguacate"
         metadata.must_be_empty
       end
 
       it "deletes the directory objects metadata in redis" do
-        old_metadata = redis.hgetall "rsm:phil:food/"
+        old_metadata = redis.hgetall "rs:m:phil:food/"
 
         put_stub = OpenStruct.new(headers: {etag: "newetag"})
         get_stub = OpenStruct.new(body: "rootbody")
@@ -197,15 +197,15 @@ describe "App" do
           end
         end
 
-        metadata = redis.hgetall "rsm:phil:food/"
+        metadata = redis.hgetall "rs:m:phil:food/"
         metadata["e"].must_equal "newetag"
         metadata["m"].length.must_equal 13
         metadata["m"].wont_equal old_metadata["m"]
 
-        food_items = redis.smembers "rsm:phil:food/:i"
+        food_items = redis.smembers "rs:m:phil:food/:i"
         food_items.must_equal ["camaron"]
 
-        root_items = redis.smembers "rsm:phil:/:i"
+        root_items = redis.smembers "rs:m:phil:/:i"
         root_items.must_equal ["food/"]
       end
 
@@ -223,13 +223,13 @@ describe "App" do
           end
         end
 
-        metadata = redis.hgetall "rsm:phil:food/"
+        metadata = redis.hgetall "rs:m:phil:food/"
         metadata.must_be_empty
 
-        food_items = redis.smembers "rsm:phil:food/:i"
+        food_items = redis.smembers "rs:m:phil:food/:i"
         food_items.must_be_empty
 
-        root_items = redis.smembers "rsm:phil:/:i"
+        root_items = redis.smembers "rs:m:phil:/:i"
         root_items.must_be_empty
       end
     end

--- a/spec/swift/app_spec.rb
+++ b/spec/swift/app_spec.rb
@@ -32,10 +32,10 @@ describe "App" do
         end
 
         metadata = redis.hgetall "rsm:phil:food/aguacate"
-        metadata["size"].must_equal "2"
-        metadata["type"].must_equal "text/plain; charset=utf-8"
-        metadata["etag"].must_equal "bla"
-        metadata["modified"].length.must_equal 13
+        metadata["s"].must_equal "2"
+        metadata["t"].must_equal "text/plain; charset=utf-8"
+        metadata["e"].must_equal "bla"
+        metadata["m"].length.must_equal 13
       end
 
       it "creates the directory objects metadata in redis" do
@@ -51,12 +51,12 @@ describe "App" do
         end
 
         metadata = redis.hgetall "rsm:phil:/"
-        metadata["etag"].must_equal "rootetag"
-        metadata["modified"].length.must_equal 13
+        metadata["e"].must_equal "rootetag"
+        metadata["m"].length.must_equal 13
 
         metadata = redis.hgetall "rsm:phil:food/"
-        metadata["etag"].must_equal "bla"
-        metadata["modified"].length.must_equal 13
+        metadata["e"].must_equal "bla"
+        metadata["m"].length.must_equal 13
 
         food_items = redis.smembers "rsm:phil:food/:i"
         food_items.each do |food_item|
@@ -82,7 +82,7 @@ describe "App" do
           last_response.status.must_equal 200
 
           metadata = redis.hgetall "rsm:phil:food/aguacate"
-          metadata["size"].must_equal "2"
+          metadata["s"].must_equal "2"
         end
 
         it "conflicts when there is a directory with same name as document" do
@@ -198,9 +198,9 @@ describe "App" do
         end
 
         metadata = redis.hgetall "rsm:phil:food/"
-        metadata["etag"].must_equal "newetag"
-        metadata["modified"].length.must_equal 13
-        metadata["modified"].wont_equal old_metadata["modified"]
+        metadata["e"].must_equal "newetag"
+        metadata["m"].length.must_equal 13
+        metadata["m"].wont_equal old_metadata["m"]
 
         food_items = redis.smembers "rsm:phil:food/:i"
         food_items.must_equal ["camaron"]

--- a/spec/swift/app_spec.rb
+++ b/spec/swift/app_spec.rb
@@ -16,7 +16,7 @@ describe "App" do
 
     before do
       purge_redis
-      redis.set "rs_config:dir_backend:phil", "new"
+      redis.set "rsc:db:phil", "new"
     end
 
     context "authorized" do
@@ -115,7 +115,7 @@ describe "App" do
       describe "directory backend configuration" do
         context "locked new backed" do
           before do
-            redis.set "rs_config:dir_backend:phil", "new-locked"
+            redis.set "rsc:db:phil", "new-locked"
           end
 
           it "responds with 503" do
@@ -130,7 +130,7 @@ describe "App" do
 
         context "locked legacy backend" do
           before do
-            redis.set "rs_config:dir_backend:phil", "legacy-locked"
+            redis.set "rsc:db:phil", "legacy-locked"
           end
 
           it "responds with 503" do
@@ -150,7 +150,7 @@ describe "App" do
 
     before do
       purge_redis
-      redis.set "rs_config:dir_backend:phil", "new"
+      redis.set "rsc:db:phil", "new"
     end
 
     context "authorized" do
@@ -239,7 +239,7 @@ describe "App" do
 
     before do
       purge_redis
-      redis.set "rs_config:dir_backend:phil", "new"
+      redis.set "rsc:db:phil", "new"
     end
 
     context "authorized" do
@@ -318,7 +318,7 @@ describe "App" do
           put "/phil/food/camaron", "yummi"
         end
 
-        redis.set "rs_config:dir_backend:phil", "legacy"
+        redis.set "rsc:db:phil", "legacy"
       end
 
       it "serves directory listing from Swift backend" do

--- a/spec/swift/app_spec.rb
+++ b/spec/swift/app_spec.rb
@@ -58,12 +58,12 @@ describe "App" do
         metadata["e"].must_equal "bla"
         metadata["m"].length.must_equal 13
 
-        food_items = redis.smembers "rs:m:phil:food/:i"
+        food_items = redis.smembers "rs:m:phil:food/:items"
         food_items.each do |food_item|
           ["camaron", "aguacate"].must_include food_item
         end
 
-        root_items = redis.smembers "rs:m:phil:/:i"
+        root_items = redis.smembers "rs:m:phil:/:items"
         root_items.must_equal ["food/"]
       end
 
@@ -202,10 +202,10 @@ describe "App" do
         metadata["m"].length.must_equal 13
         metadata["m"].wont_equal old_metadata["m"]
 
-        food_items = redis.smembers "rs:m:phil:food/:i"
+        food_items = redis.smembers "rs:m:phil:food/:items"
         food_items.must_equal ["camaron"]
 
-        root_items = redis.smembers "rs:m:phil:/:i"
+        root_items = redis.smembers "rs:m:phil:/:items"
         root_items.must_equal ["food/"]
       end
 
@@ -226,10 +226,10 @@ describe "App" do
         metadata = redis.hgetall "rs:m:phil:food/"
         metadata.must_be_empty
 
-        food_items = redis.smembers "rs:m:phil:food/:i"
+        food_items = redis.smembers "rs:m:phil:food/:items"
         food_items.must_be_empty
 
-        root_items = redis.smembers "rs:m:phil:/:i"
+        root_items = redis.smembers "rs:m:phil:/:items"
         root_items.must_be_empty
       end
     end

--- a/spec/swift/app_spec.rb
+++ b/spec/swift/app_spec.rb
@@ -35,7 +35,7 @@ describe "App" do
         metadata["size"].must_equal "2"
         metadata["type"].must_equal "text/plain; charset=utf-8"
         metadata["etag"].must_equal "bla"
-        metadata["modified"].must_equal nil
+        metadata["modified"].length.must_equal 13
       end
 
       it "creates the directory objects metadata in redis" do


### PR DESCRIPTION
Can be run via `ENVIRONMENT=staging ./migrate_metadata_to_redis.rb <username>`.

When setting the environment variable `DRYRUN=true`, nothing is written to Redis.

Logs are written to `log/migrate_metadata_to_redis.log`. Loglevel can be set via e.g. `LOGLEVEL=debug` (default is `INFO`).

After the migration is run successfully, the directory backend type is set to `new` for that user. When the migration failed, the backend type is set to `legacy`. The username of a failed migration is logged separately to `log/failed_migration.log`. This can be used for retrying the migration for those users later on. The actual error message is logged to the normal log file.

I haven't tried yet, if the way I'm connecting to Redis also works with the new cluster configuration we are using in production.