### PR TITLE
Log user's storage size in Redis

### DIFF
--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -159,6 +159,7 @@ module RemoteStorage
       if update_metadata_object(user, directory, key, metadata)
         if metadata_changed?(existing_metadata, metadata)
           update_dir_objects(user, directory, timestamp, checksum_for(data))
+          log_size_difference(user, existing_metadata["s"], metadata[:s])
         end
 
         server.headers["ETag"] = %Q("#{res.headers[:etag]}")
@@ -166,6 +167,11 @@ module RemoteStorage
       else
         server.halt 500
       end
+    end
+
+    def log_size_difference(user, old_size, new_size)
+      delta = new_size.to_i - old_size.to_i
+      redis.incrby "rs:s:#{user}", delta
     end
 
     def checksum_for(data)
@@ -182,6 +188,7 @@ module RemoteStorage
       end
 
       do_delete_request(url)
+      log_size_difference(user, existing_metadata["s"], 0)
       delete_metadata_objects(user, directory, key)
       delete_dir_objects(user, directory)
 


### PR DESCRIPTION
closes #81

Still needs a migration for setting the current size for all users. But I'd suggest to do that in platform using Resque workers.