### PR TITLE
Return 401 when getting an empty bearer token

### DIFF
--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -24,7 +24,7 @@ module RemoteStorage
         return true if ["GET", "HEAD"].include?(request_method) && !listing
       end
 
-      server.halt 401, "Unauthorized" if token.empty?
+      server.halt 401, "Unauthorized" if token.nil? || token.empty?
 
       authorizations = redis.smembers("authorizations:#{user}:#{token}")
       permission = directory_permission(authorizations, directory)

--- a/spec/swift/app_spec.rb
+++ b/spec/swift/app_spec.rb
@@ -280,9 +280,18 @@ describe "App" do
     end
 
     context "not authorized" do
-
       describe "with no token" do
         it "says it's not authorized" do
+          delete "/phil/food/aguacate"
+
+          last_response.status.must_equal 401
+          last_response.body.must_equal "Unauthorized"
+        end
+      end
+
+      describe "with empty token" do
+        it "says it's not authorized" do
+          header "Authorization", "Bearer "
           delete "/phil/food/aguacate"
 
           last_response.status.must_equal 401


### PR DESCRIPTION
For example:

Authorization: Bearer

The cause of the empty bearer also needs to be investigated