### PR TITLE
Reload swift token from file every 30 minutes

### DIFF
--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -447,7 +447,7 @@ module RemoteStorage
     end
 
     def swift_token
-      reload_swift_token if Time.now - settings.swift_token_loaded_at > 3600
+      reload_swift_token if Time.now - settings.swift_token_loaded_at > 1800
 
       settings.swift_token
     end


### PR DESCRIPTION
We have seen requests fail because of an expired token that was loaded
from file less than an hour ago