### PR TITLE
Swift migration for single shared container

### DIFF
--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -20,6 +20,10 @@ module RemoteStorage
     def authorize_request(user, directory, token, listing=false)
       request_method = server.env["REQUEST_METHOD"]
 
+      if request_method.match(/PUT|DELETE/) && redis.sismember("migration_in_progress", user)
+        server.halt 503, "Down for maintenance. Back soon!"
+      end
+
       if directory.split("/").first == "public"
         return true if ["GET", "HEAD"].include?(request_method) && !listing
       end

--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -386,7 +386,7 @@ module RemoteStorage
       if container_migration(user)
         "#{base_url}/rs:#{settings.environment.to_s.chars.first}:#{user}"
       else
-        "#{base_url}/#{container_for(user)}"
+        "#{base_url}/rs:documents:#{settings.environment.to_s}/#{user}"
       end
     end
 
@@ -396,10 +396,6 @@ module RemoteStorage
 
     def base_url
       @base_url ||= settings.swift["host"]
-    end
-
-    def container_for(user)
-      "rs:documents:#{settings.environment.to_s}/#{user}"
     end
 
     def container_migration(user)

--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -384,9 +384,9 @@ module RemoteStorage
 
     def container_url_for(user)
       if container_migration(user)
-        user_container_url
+        "#{base_url}/rs:#{settings.environment.to_s.chars.first}:#{user}"
       else
-        "#{base_url}/rs:documents:#{settings.environment.to_s}/#{user}"
+        "#{base_url}/#{container_for(user)}"
       end
     end
 
@@ -399,7 +399,7 @@ module RemoteStorage
     end
 
     def container_for(user)
-      "rs:#{settings.environment.to_s.chars.first}:#{user}"
+      "rs:documents:#{settings.environment.to_s}/#{user}"
     end
 
     def container_migration(user)

--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -396,14 +396,6 @@ module RemoteStorage
       File.join [container_url_for(user), escape(directory), escape(key)].compact
     end
 
-    def url_for_directory(user, directory)
-      if directory.empty?
-        container_url_for(user)
-      else
-        "#{container_url_for(user)}/#{escape(directory)}"
-      end
-    end
-
     def base_url
       @base_url ||= settings.swift["host"]
     end

--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -399,7 +399,7 @@ module RemoteStorage
     end
 
     def container_migration(user)
-      redis.get("rs:container_migration:#{user}")
+      redis.hget("rs:container_migration", user)
     end
 
     def default_headers

--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -383,7 +383,13 @@ module RemoteStorage
     end
 
     def container_url_for(user)
-      "#{base_url}/#{container_for(user)}"
+      user_container_url = "#{base_url}/#{container_for(user)}"
+      res = do_head_request(user_container_url)
+      # User before container migration
+      return user_container_url if res.status == 200
+    rescue RestClient::ResourceNotFound
+      # User after container migration
+      "#{base_url}/rs:documents:#{settings.environment.to_s}/#{user}"
     end
 
     def url_for_key(user, directory, key)

--- a/migrate_to_single_container.rb
+++ b/migrate_to_single_container.rb
@@ -35,7 +35,7 @@ class Migrator
     logger.info "Starting migration for '#{username}'"
     set_container_migration_state("in_progress")
     begin
-      work_on_dir("", "")
+      copy_all_documents
     rescue Exception => ex
       logger.error "Error migrating documents for '#{username}': #{ex}"
       set_container_migration_state("not_started")
@@ -48,8 +48,8 @@ class Migrator
     logger.info "Finished migration for '#{username}'"
   end
 
-  def is_dir?(name)
-    name[-1] == "/"
+  def is_document?(name)
+    name[-1] != "/"
   end
 
   def set_container_migration_state(type)
@@ -60,31 +60,26 @@ class Migrator
     redis.hdel("rs:container_migration", username) unless dry_run
   end
 
-  def work_on_dir(directory, parent_directory)
-    full_directory = "#{parent_directory}#{directory}"
-    logger.debug "Retrieving listing for '#{full_directory}'"
+  def copy_all_documents
+    logger.debug "Retrieving object listing"
 
-    listing = get_directory_listing_from_swift("#{full_directory}")
+    listing = get_directory_listing_from_swift
 
-    logger.debug "Listing for '#{full_directory}': #{listing}"
+    logger.debug "Full listing: #{listing}"
 
     if listing
       listing.split("\n").each do |item|
-        if is_dir? item
-          # get dir listing and repeat
-          work_on_dir(item, "#{parent_directory}") unless item == full_directory
-        else
-          copy_document("#{parent_directory}", item)
+        if is_document? item
+          copy_document(item)
         end
       end
     end
   end
 
-  def copy_document(directory, document)
-    old_document_url = "#{url_for_directory(@username, directory)}/#{escape(document)}"
+  def copy_document(document_path)
+    old_document_url = "#{container_url_for(@username)}/#{escape(document_path)}"
 
-    full_path = [directory, document].reject(&:empty?).join('/')
-    new_document_path = "rs:documents:#{environment.to_s.downcase}/#{@username}/#{escape(full_path)}"
+    new_document_path = "rs:documents:#{environment.to_s.downcase}/#{@username}/#{escape(document_path)}"
 
     logger.debug "Copying document from #{old_document_url} to #{new_document_path}"
     do_copy_request(old_document_url, new_document_path) unless dry_run
@@ -94,30 +89,14 @@ class Migrator
     @redis ||= Redis.new(@settings["redis"].symbolize_keys)
   end
 
-  def get_directory_listing_from_swift(directory)
-    is_root_listing = directory.empty?
-
-    get_response = nil
-
-    if is_root_listing
-      get_response = do_get_request("#{container_url_for(@username)}/?delimiter=/&prefix=")
-    else
-      get_response = do_get_request("#{container_url_for(@username)}/?delimiter=/&prefix=#{escape(directory)}")
-    end
+  def get_directory_listing_from_swift
+    get_response = do_get_request("#{container_url_for(@username)}/?prefix=")
 
     get_response.body
   end
 
-  def do_head_request(url, &block)
-    RestClient.head(url, default_headers, &block)
-  end
-
   def do_get_request(url, &block)
     RestClient.get(url, default_headers, &block)
-  end
-
-  def do_put_request(url, data, content_type)
-    RestClient.put(url, data, default_headers.merge({content_type: content_type}))
   end
 
   def do_copy_request(url, destination_path)
@@ -130,14 +109,6 @@ class Migrator
 
   def default_headers
     {"x-auth-token" => @swift_token}
-  end
-
-  def url_for_directory(user, directory)
-    if directory.empty?
-      container_url_for(user)
-    else
-      "#{container_url_for(user)}/#{escape(directory)}"
-    end
   end
 
   def container_url_for(user)

--- a/migrate_to_single_container.rb
+++ b/migrate_to_single_container.rb
@@ -1,0 +1,180 @@
+#!/usr/bin/env ruby
+
+require "rubygems"
+require "bundler/setup"
+require "rest_client"
+require "redis"
+require "yaml"
+require "logger"
+require "json"
+require "active_support/core_ext/hash"
+
+class Migrator
+
+  attr_accessor :username, :base_url, :swift_host, :swift_token,
+                :environment, :dry_run, :settings, :logger
+
+  def initialize(username)
+    @username = username
+
+    @environment = ENV["ENVIRONMENT"] || "staging"
+    @settings = YAML.load(File.read('config.yml'))[@environment]
+
+    @swift_host = @settings["swift"]["host"]
+    @swift_token = File.read("tmp/swift_token.txt").strip
+
+    @dry_run = ENV["DRYRUN"] || false # disables writing anything when true
+
+    @logger = Logger.new("log/migrate_to_single_container.log")
+    log_level = ENV["LOGLEVEL"] || "INFO"
+    logger.level = Kernel.const_get "Logger::#{log_level}"
+    logger.progname = username
+  end
+
+  def migrate
+    logger.info "Starting migration for '#{username}'"
+    set_container_migration_state("in_progress")
+    begin
+      work_on_dir("", "")
+    rescue Exception => ex
+      logger.error "Error migrating documents for '#{username}': #{ex}"
+      set_container_migration_state("not_started")
+      # write username to file for later reference
+      File.open('log/failed_migration.log', 'a') { |f| f.puts username }
+      exit 1
+    end
+    delete_container_migration_state
+    File.open('log/finished_migration.log', 'a') { |f| f.puts username }
+    logger.info "Finished migration for '#{username}'"
+  end
+
+  def is_dir?(name)
+    name[-1] == "/"
+  end
+
+  def set_container_migration_state(type)
+    redis.set("rs:container_migration:#{username}", type) unless dry_run
+  end
+
+  def delete_container_migration_state
+    redis.del("rs:container_migration:#{username}") unless dry_run
+  end
+
+  def work_on_dir(directory, parent_directory)
+    logger.debug "Retrieving listing for '#{parent_directory}#{directory}'"
+
+    listing = get_directory_listing_from_swift("#{parent_directory}#{directory}")
+
+    if listing
+      listing.split("\n").each do |item|
+        if is_dir? item
+          # get dir listing and repeat
+          work_on_dir(item, "#{parent_directory}")
+        else
+          copy_document("#{parent_directory}", item)
+        end
+      end
+    end
+  end
+
+  def copy_document(directory, document)
+    old_document_url = "#{url_for_directory(@username, directory)}/#{escape(document)}"
+    new_document_url = "#{new_url_for_directory(@username, directory)}/#{escape(document)}"
+
+    logger.debug "Copying document from #{old_document_url} to #{new_document_url}"
+
+    response = do_get_request(old_document_url)
+
+    unless dry_run
+      do_put_request(new_document_url, response.body, response.headers[:content_type])
+    end
+  end
+
+  def redis
+    @redis ||= Redis.new(@settings["redis"].symbolize_keys)
+  end
+
+  def get_directory_listing_from_swift(directory)
+    is_root_listing = directory.empty?
+
+    get_response = nil
+
+    do_head_request("#{url_for_directory(@username, directory)}") do |response|
+      return "" if response.code == 404
+
+      if is_root_listing
+        get_response = do_get_request("#{container_url_for(@username)}/?path=")
+      else
+        get_response = do_get_request("#{container_url_for(@username)}/?path=#{escape(directory)}")
+      end
+    end
+
+    get_response.body
+  end
+
+  def do_head_request(url, &block)
+    RestClient.head(url, default_headers, &block)
+  end
+
+  def do_get_request(url, &block)
+    RestClient.get(url, default_headers, &block)
+  end
+
+  def do_put_request(url, data, content_type)
+    RestClient.put(url, data, default_headers.merge({content_type: content_type}))
+  end
+
+  def default_headers
+    {"x-auth-token" => @swift_token}
+  end
+
+  def url_for_directory(user, directory)
+    if directory.empty?
+      container_url_for(user)
+    else
+      "#{container_url_for(user)}/#{escape(directory)}"
+    end
+  end
+
+  def container_url_for(user)
+    "#{base_url}/#{container_for(user)}"
+  end
+
+  def new_container_url_for(user)
+    "#{base_url}/rs:documents:#{environment.to_s.downcase}/#{user}"
+  end
+
+  def new_url_for_directory(user, directory)
+    if directory.empty?
+      new_container_url_for(user)
+    else
+      "#{new_container_url_for(user)}/#{escape(directory)}"
+    end
+  end
+
+  def base_url
+    @base_url ||= @swift_host
+  end
+
+  def container_for(user)
+    "rs:#{environment.to_s.chars.first}:#{user}"
+  end
+
+  def escape(url)
+    # We want spaces to turn into %20 and slashes to stay slashes
+    CGI::escape(url).gsub('+', '%20').gsub('%2F', '/')
+  end
+end
+
+username = ARGV[0]
+
+unless username
+  puts "No username given."
+  puts "Usage:"
+  puts "ENVIRONMENT=staging ./migrate_to_single_container.rb <username>"
+  exit 1
+end
+
+migrator = Migrator.new username
+migrator.migrate
+

--- a/migrate_to_single_container.rb
+++ b/migrate_to_single_container.rb
@@ -53,11 +53,11 @@ class Migrator
   end
 
   def set_container_migration_state(type)
-    redis.set("rs:container_migration:#{username}", type) unless dry_run
+    redis.hset("rs:container_migration", username, type) unless dry_run
   end
 
   def delete_container_migration_state
-    redis.del("rs:container_migration:#{username}") unless dry_run
+    redis.hdel("rs:container_migration", username) unless dry_run
   end
 
   def work_on_dir(directory, parent_directory)


### PR DESCRIPTION
Before merging/deploying, we need to create Redis entries for every user with key `rs:container_migration:#{username}` and content `not_started`.

Connected to 5apps/chef#680