### PR TITLE
Handle out of sync metadata in Redis on PUTs

### DIFF
--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -52,7 +52,9 @@ module RemoteStorage
 
       set_response_headers(res)
 
-      none_match = (server.env["HTTP_IF_NONE_MATCH"] || "").gsub(/^"?W\//, "").split(",").map(&:strip)
+      none_match = (server.env["HTTP_IF_NONE_MATCH"] || "").split(",")
+                                                           .map(&:strip)
+                                                           .map { |s| s.gsub(/^"?W\//, "") }
       server.halt 304 if none_match.include? %Q("#{res.headers[:etag]}")
 
       return res.body
@@ -71,7 +73,9 @@ module RemoteStorage
 
       server.headers["Content-Type"] = "application/ld+json"
 
-      none_match = (server.env["HTTP_IF_NONE_MATCH"] || "").gsub(/^"?W\//, "").split(",").map(&:strip)
+      none_match = (server.env["HTTP_IF_NONE_MATCH"] || "").split(",")
+                                                           .map(&:strip)
+                                                           .map { |s| s.gsub(/^"?W\//, "") }
 
       if etag
         server.halt 304 if none_match.include? %Q("#{etag}")

--- a/lib/remote_storage/swift.rb
+++ b/lib/remote_storage/swift.rb
@@ -147,7 +147,12 @@ module RemoteStorage
         unless required_match == %Q("#{existing_metadata["e"]}")
 
           # get actual metadata and compare in case redis metadata became out of sync
-          head_res = do_head_request(url)
+          begin
+            head_res = do_head_request(url)
+          # The file doesn't exist in Orbit, return 412
+          rescue RestClient::ResourceNotFound
+            server.halt 412, "Precondition Failed"
+          end
 
           if required_match == %Q("#{head_res.headers[:etag]}")
             # log previous size difference that was missed ealier because of redis failure


### PR DESCRIPTION
When the IF-MATCH comparison fails, it could be because the metadata might not have been written to Redis on the previous PUT.

This change checks the actual metadata on the Swift server to be sure.