### PR TITLE
Use all keys from the config file's redis section in the specs

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,7 +35,7 @@ alias context describe
 
 if app.settings.respond_to? :redis
   def redis
-    @redis ||= Redis.new(host: app.settings.redis["host"], port: app.settings.redis["port"])
+    @redis ||= Redis.new(app.settings.redis.symbolize_keys)
   end
 
   def purge_redis


### PR DESCRIPTION
You can pass a db index, and the code was using it, but not the specs