### PR TITLE
Set the Content-Length on a HEAD requests

### DIFF
--- a/lib/remote_storage/rest_provider.rb
+++ b/lib/remote_storage/rest_provider.rb
@@ -47,6 +47,7 @@ module RemoteStorage
       server.headers["ETag"]          = %Q("#{metadata["e"]}")
       server.headers["Last-Modified"] = Time.at(metadata["m"].to_i / 1000).httpdate
       server.headers["Content-Type"]  = metadata["t"]
+      server.headers["Content-Length"]  = metadata["s"]
 
       if none_match.include? %Q("#{metadata["e"]}")
         server.halt 304

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -616,6 +616,7 @@ shared_examples_for 'a REST adapter' do
             last_response.headers["Cache-Control"].must_equal "no-cache"
             last_response.headers["Last-Modified"].must_equal "Fri, 04 Mar 2016 12:20:18 GMT"
             last_response.headers["Content-Type"].must_equal "text/plain; charset=utf-8"
+            last_response.headers["Content-Length"].must_equal "2"
           end
 
           it "responds with 304 when IF_NONE_MATCH header contains the ETag" do


### PR DESCRIPTION
We get it as part of the Redis metadata

RFC: https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13

Follow-up to #122 