### PR TITLE
Set the response headers from Redis metadata on GET requests

### DIFF
--- a/lib/remote_storage/rest_provider.rb
+++ b/lib/remote_storage/rest_provider.rb
@@ -69,7 +69,7 @@ module RemoteStorage
 
       res = do_get_request(url)
 
-      set_response_headers(res.headers)
+      set_response_headers(metadata)
 
       return res.body
     rescue RestClient::ResourceNotFound
@@ -210,11 +210,11 @@ module RemoteStorage
       raise NotImplementedError
     end
 
-    def set_response_headers(headers)
-      server.headers["ETag"]           = format_etag(headers[:etag])
-      server.headers["Content-Type"]   = headers[:content_type]
-      server.headers["Content-Length"] = headers[:content_length]
-      server.headers["Last-Modified"]  = headers[:last_modified]
+    def set_response_headers(metadata)
+      server.headers["ETag"]           = %Q("#{metadata["e"]}")
+      server.headers["Last-Modified"]  = Time.at(metadata["m"].to_i / 1000).httpdate
+      server.headers["Content-Type"]   = metadata["t"]
+      server.headers["Content-Length"] = metadata["s"]
     end
 
     def extract_category(directory)

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -437,7 +437,8 @@ shared_examples_for 'a REST adapter' do
           get "/phil/food/aguacate"
 
           last_response.status.must_equal 200
-          last_response.headers["ETag"].must_equal "\"0817etag\""
+          # ETag is coming from the Redis metadata, not the storage server (which has "0817etag")
+          last_response.headers["ETag"].must_equal "\"0815etag\""
           last_response.headers["Cache-Control"].must_equal "no-cache"
           last_response.headers["Content-Type"].must_equal "text/plain; charset=utf-8"
         end


### PR DESCRIPTION
This should fix a problem with wrong Content-Type headers coming from SOS.