### PR TITLE
Content-Range support

### DIFF
--- a/lib/remote_storage/rest_provider.rb
+++ b/lib/remote_storage/rest_provider.rb
@@ -69,6 +69,11 @@ module RemoteStorage
 
       res = do_get_request(url)
 
+      if res.headers[:content_range]
+        # Partial content
+        server.headers["Content-Range"] = res.headers[:content_range]
+        server.status 206
+      end
       set_response_headers(metadata)
 
       return res.body

--- a/lib/remote_storage/rest_provider.rb
+++ b/lib/remote_storage/rest_provider.rb
@@ -410,7 +410,9 @@ module RemoteStorage
 
     def do_get_request(url, &block)
       deal_with_unauthorized_requests do
-        RestClient.get(url, default_headers, &block)
+        headers = { }
+        headers["Range"] = server.env["HTTP_RANGE"] if server.env["HTTP_RANGE"]
+        RestClient.get(url, default_headers.merge(headers), &block)
       end
     end
 

--- a/lib/remote_storage/s3.rb
+++ b/lib/remote_storage/s3.rb
@@ -32,8 +32,10 @@ module RemoteStorage
 
     def do_get_request(url, &block)
       deal_with_unauthorized_requests do
+        headers = { }
+        headers["Range"] = server.env["HTTP_RANGE"] if server.env["HTTP_RANGE"]
         authorization_headers = authorization_headers_for("GET", url)
-        RestClient.get(url, authorization_headers, &block)
+        RestClient.get(url, authorization_headers.merge(headers), &block)
       end
     end
 

--- a/liquor-cabinet.rb
+++ b/liquor-cabinet.rb
@@ -68,8 +68,9 @@ class LiquorCabinet < Sinatra::Base
     before path do
       headers 'Access-Control-Allow-Origin' => '*',
               'Access-Control-Allow-Methods' => 'GET, PUT, DELETE',
-              'Access-Control-Allow-Headers' => 'Authorization, Content-Type, Origin, If-Match, If-None-Match',
-              'Access-Control-Expose-Headers' => 'ETag, Content-Length'
+              'Access-Control-Allow-Headers' => 'Authorization, Content-Type, Origin, If-Match, If-None-Match, Range',
+              'Access-Control-Expose-Headers' => 'ETag, Content-Length, Content-Range',
+              'Accept-Ranges' => 'bytes'
       headers['Access-Control-Allow-Origin'] = env["HTTP_ORIGIN"] if env["HTTP_ORIGIN"]
       headers['Cache-Control'] = 'no-cache'
 

--- a/spec/s3/app_spec.rb
+++ b/spec/s3/app_spec.rb
@@ -16,12 +16,20 @@ describe "S3 provider" do
     stub_request(:put, "#{container_url_for("phil")}/food/aguacate").
       with(body: "aye").
       to_return(status: 200, headers: { etag: '"0915etag"', date: "Fri, 04 Mar 2016 12:20:18 GMT" })
+    stub_request(:put, "#{container_url_for("phil")}/public/shares/example.jpg").
+      to_return(status: 200, headers: { etag: '"0817etag"', content_type: "image/jpeg", date: "Fri, 04 Mar 2016 12:20:18 GMT" })
+    stub_request(:put, "#{container_url_for("phil")}/public/shares/example_partial.jpg").
+      to_return(status: 200, headers: { etag: '"0817etag"', content_type: "image/jpeg", date: "Fri, 04 Mar 2016 12:20:18 GMT" })
     stub_request(:head, "#{container_url_for("phil")}/food/aguacate").
       to_return(status: 200, headers: { last_modified: "Fri, 04 Mar 2016 12:20:18 GMT" })
     stub_request(:get, "#{container_url_for("phil")}/food/aguacate").
       to_return(status: 200, body: "rootbody", headers: { etag: '"0817etag"', content_type: "text/plain; charset=utf-8" })
     stub_request(:delete, "#{container_url_for("phil")}/food/aguacate").
       to_return(status: 200, headers: { etag: '"0815etag"' })
+    stub_request(:get, "#{container_url_for("phil")}/public/shares/example.jpg").
+      to_return(status: 200, body: "", headers: { etag: '"0817etag"', content_type: "image/jpeg" })
+    stub_request(:get, "#{container_url_for("phil")}/public/shares/example_partial.jpg").
+      to_return(status: 206, body: "", headers: { etag: '"0817etag"', content_type: "image/jpeg", content_range: "bytes 0-16/128" })
 
     # Write new content to check the metadata in Redis
     stub_request(:put, "#{container_url_for("phil")}/food/banano").

--- a/spec/swift/app_spec.rb
+++ b/spec/swift/app_spec.rb
@@ -16,12 +16,20 @@ describe "Swift provider" do
     stub_request(:put, "#{container_url_for("phil")}/food/aguacate").
       with(body: "aye").
       to_return(status: 200, headers: { etag: "0915etag", last_modified: "Fri, 04 Mar 2016 12:20:18 GMT" })
+    stub_request(:put, "#{container_url_for("phil")}/public/shares/example.jpg").
+      to_return(status: 200, headers: { etag: '"0817etag"', content_type: "image/jpeg", last_modified: "Fri, 04 Mar 2016 12:20:18 GMT" })
+    stub_request(:put, "#{container_url_for("phil")}/public/shares/example_partial.jpg").
+      to_return(status: 200, headers: { etag: '"0817etag"', content_type: "image/jpeg", last_modified: "Fri, 04 Mar 2016 12:20:18 GMT" })
     stub_request(:head, "#{container_url_for("phil")}/food/aguacate").
       to_return(status: 200, headers: { last_modified: "Fri, 04 Mar 2016 12:20:18 GMT" })
     stub_request(:get, "#{container_url_for("phil")}/food/aguacate").
       to_return(status: 200, body: "rootbody", headers: { etag: "0817etag", content_type: "text/plain; charset=utf-8" })
     stub_request(:delete, "#{container_url_for("phil")}/food/aguacate").
       to_return(status: 200, headers: { etag: "0815etag" })
+    stub_request(:get, "#{container_url_for("phil")}/public/shares/example.jpg").
+      to_return(status: 200, body: "", headers: { etag: '"0817etag"', content_type: "image/jpeg" })
+    stub_request(:get, "#{container_url_for("phil")}/public/shares/example_partial.jpg").
+      to_return(status: 206, body: "", headers: { etag: '"0817etag"', content_type: "image/jpeg", content_range: "bytes 0-16/128" })
 
     # Write new content to check the metadata in Redis
     stub_request(:put, "#{container_url_for("phil")}/food/banano").


### PR DESCRIPTION
Example, getting the first 65 bytes of an MP4 file:

```
$ curl -H "Range: bytes=0-64" "https://storage.5apps.dev/gregkare/public/shares/200102-1407-Tenac003%231.m4a" -v
*   Trying 192.168.42.23...
* TCP_NODELAY set
* Connected to storage.5apps.dev (192.168.42.23) port 443 (#0)
* ALPN, offering h2
* ALPN, offering http/1.1
* Cipher selection: ALL:!EXPORT:!EXPORT40:!EXPORT56:!aNULL:!LOW:!RC4:@STRENGTH
* successfully set certificate verify locations:
*   CAfile: /etc/ssl/cert.pem
  CApath: none
* TLSv1.2 (OUT), TLS handshake, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Server hello (2):
* TLSv1.2 (IN), TLS handshake, Certificate (11):
* TLSv1.2 (IN), TLS handshake, Server key exchange (12):
* TLSv1.2 (IN), TLS handshake, Server finished (14):
* TLSv1.2 (OUT), TLS handshake, Client key exchange (16):
* TLSv1.2 (OUT), TLS change cipher, Client hello (1):
* TLSv1.2 (OUT), TLS handshake, Finished (20):
* TLSv1.2 (IN), TLS change cipher, Client hello (1):
* TLSv1.2 (IN), TLS handshake, Finished (20):
* SSL connection using TLSv1.2 / ECDHE-RSA-AES128-GCM-SHA256
* ALPN, server accepted to use h2
* Server certificate:
*  subject: C=NL; ST=Amsterdam; O=5apps; OU=Internal; CN=5apps Internal
*  start date: Jan  2 18:34:15 2019 GMT
*  expire date: Jan  1 18:34:15 2024 GMT
*  subjectAltName: host "storage.5apps.dev" matched cert's "*.5apps.dev"
*  issuer: C=NL; ST=Amsterdam; O=5apps; OU=Internal; CN=5apps Internal
*  SSL certificate verify ok.
* Using HTTP2, server supports multi-use
* Connection state changed (HTTP/2 confirmed)
* Copying HTTP/2 data in stream buffer to connection buffer after upgrade: len=0
* Using Stream ID: 1 (easy handle 0x7feacd809200)
> GET /gregkare/public/shares/200102-1407-Tenac003%231.m4a HTTP/2
> Host: storage.5apps.dev
> User-Agent: curl/7.54.0
> Accept: */*
> Range: bytes=0-64
>
* Connection state changed (MAX_CONCURRENT_STREAMS updated)!
< HTTP/2 206
< server: openresty
< date: Thu, 02 Jan 2020 17:25:40 GMT
< content-type: audio/x-m4a; charset=binary
< content-length: 65
< access-control-allow-origin: *
< access-control-allow-methods: GET, PUT, DELETE
< access-control-allow-headers: Authorization, Content-Type, Origin, If-Match, If-None-Match, Range
< access-control-expose-headers: ETag, Content-Length, Content-Range
< accept-ranges: bytes
< cache-control: no-cache
< content-range: bytes 0-64/6616063
< etag: "0450dbd2631e5c38924739b8643d8075"
< last-modified: Thu, 02 Jan 2020 14:07:39 GMT
< strict-transport-security: max-age=15768000; includeSubDomains; preload
<
* Connection #0 to host storage.5apps.dev left intact
 ftypM4A M4A mp42isommoovlmvhdƣƣD
```

New/updated response headers:

```
# Returns a Partial Content status https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/206
< HTTP/2 206
# Range
< access-control-allow-headers: Authorization, Content-Type, Origin, If-Match, If-None-Match, Range
# Content-Range
< access-control-expose-headers: ETag, Content-Length, Content-Range
< accept-ranges: bytes
< content-range: bytes 0-64/6616063
```

Do you have any pointer about getting an `<audio>` HTML element to use the `Range` header? So far I could only get it to work using cURL

Refs #82 