### PR TITLE
Validate the Content-Type on PUT requests

### DIFF
--- a/lib/remote_storage/rest_provider.rb
+++ b/lib/remote_storage/rest_provider.rb
@@ -118,6 +118,9 @@ module RemoteStorage
     end
 
     def put_data(user, directory, key, data, content_type)
+      # Do not try to perform the PUT request when the Content-Type does not
+      # look like a MIME type
+      server.halt 415 unless content_type.match(/^.+\/.+/i)
       server.halt 400 if server.env["HTTP_CONTENT_RANGE"]
       server.halt 409, "Conflict" if has_name_collision?(user, directory, key)
 
@@ -506,10 +509,5 @@ module RemoteStorage
       items
     end
 
-    def validate_content_type(content_type)
-      # Do not try to perform the PUT request when the Content-Type does not
-      # look like a MIME type
-      server.halt 415 unless content_type.match(/^.+\/.+/i)
-    end
   end
 end

--- a/lib/remote_storage/rest_provider.rb
+++ b/lib/remote_storage/rest_provider.rb
@@ -506,5 +506,10 @@ module RemoteStorage
       items
     end
 
+    def validate_content_type(content_type)
+      # Do not try to perform the PUT request when the Content-Type does not
+      # look like a MIME type
+      server.halt 415 unless content_type.match(/^.+\/.+/i)
+    end
   end
 end

--- a/lib/remote_storage/s3.rb
+++ b/lib/remote_storage/s3.rb
@@ -16,8 +16,6 @@ module RemoteStorage
     end
 
     def do_put_request(url, data, content_type)
-      validate_content_type(content_type)
-
       deal_with_unauthorized_requests do
         md5 = Digest::MD5.base64digest(data)
         authorization_headers = authorization_headers_for(

--- a/lib/remote_storage/s3.rb
+++ b/lib/remote_storage/s3.rb
@@ -16,6 +16,8 @@ module RemoteStorage
     end
 
     def do_put_request(url, data, content_type)
+      validate_content_type(content_type)
+
       deal_with_unauthorized_requests do
         md5 = Digest::MD5.base64digest(data)
         authorization_headers = authorization_headers_for(

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -232,6 +232,16 @@ shared_examples_for 'a REST adapter' do
           _(last_response.body).must_equal "Precondition Failed"
         end
       end
+
+      describe "Content-Type" do
+        it "must be in the type/subtype format" do
+          header "Content-Type", "text"
+
+          put "/phil/food/invalid_content_type", "invalid"
+
+          _(last_response.status).must_equal 415
+        end
+      end
     end
 
   end


### PR DESCRIPTION
Return a 415 (https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415) when the
Content-Type does not look like a valid MIME type (in the `type/subtype` format)

Refs #137