### PR TITLE
Fix deprecation warnings

### DIFF
--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -423,8 +423,8 @@ shared_examples_for 'a REST adapter' do
         it "returns the required response headers" do
           get "/phil/public/shares/example.jpg"
 
-          last_response.status.must_equal 200
-          last_response.headers["Content-Type"].must_equal "image/jpeg"
+          _(last_response.status).must_equal 200
+          _(last_response.headers["Content-Type"]).must_equal "image/jpeg"
         end
       end
 
@@ -442,8 +442,8 @@ JFIFddDuckyA␍⎺␉␊␍
           header 'Range', 'bytes=0-16'
           get "/phil/public/shares/example_partial.jpg"
 
-          last_response.status.must_equal 206
-          last_response.headers["Content-Type"].must_equal "image/jpeg"
+          _(last_response.status).must_equal 206
+          _(last_response.headers["Content-Type"]).must_equal "image/jpeg"
         end
       end
     end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -1,5 +1,3 @@
-require_relative "./spec_helper"
-
 shared_examples_for 'a REST adapter' do
   include Rack::Test::Methods
 


### PR DESCRIPTION
... and a circular `require`.

The remaining warnings are coming mostly from `sinatra-contrib`s `config_file`. Has to be fixed upstream.