### PR TITLE
Allow clients to cache OPTIONS results for 2 hours

### DIFF
--- a/liquor-cabinet.rb
+++ b/liquor-cabinet.rb
@@ -79,6 +79,7 @@ class LiquorCabinet < Sinatra::Base
     end
 
     options path do
+      headers['Access-Control-Max-Age'] = '7200'
       halt 200
     end
   end

--- a/spec/shared_examples.rb
+++ b/spec/shared_examples.rb
@@ -14,6 +14,18 @@ shared_examples_for 'a REST adapter' do
     _(last_response.status).must_equal 404
   end
 
+  describe "OPTIONS requests" do
+
+    it "returns CORS headers" do
+      options "/phil/food/aguacate"
+
+      _(last_response.headers["Access-Control-Allow-Origin"]).wont_be_nil
+      _(last_response.headers["Access-Control-Allow-Methods"]).must_equal "GET, PUT, DELETE"
+      _(last_response.headers["Access-Control-Max-Age"].to_i).must_be :> , 10
+    end
+
+  end
+
   describe "PUT requests" do
 
     before do


### PR DESCRIPTION
Clients that use `Fetch` can cache the results of `OPTIONS` requests, based on the value of `Access-Control-Max-Age`:

https://fetch.spec.whatwg.org/#http-access-control-max-age

/ht @DougReeder: https://github.com/remotestorage/armadietto/pull/86